### PR TITLE
adjustments to ZillionEarlyScope

### DIFF
--- a/worlds/zillion/__init__.py
+++ b/worlds/zillion/__init__.py
@@ -145,9 +145,6 @@ class ZillionWorld(World):
 
         self._make_item_maps(zz_op.start_char)
 
-        if self.multiworld.early_scope[self.player]:
-            self.multiworld.early_items[self.player]['Scope'] = 1
-
     def create_regions(self) -> None:
         assert self.zz_system.randomizer, "generate_early hasn't been called"
         assert self.id_to_zz_item, "generate_early hasn't been called"

--- a/worlds/zillion/docs/setup_en.md
+++ b/worlds/zillion/docs/setup_en.md
@@ -49,10 +49,6 @@ guide: [Basic Multiworld Setup Guide](/tutorial/Archipelago/setup/en)
 The [player settings page](/games/Zillion/player-settings) on the website allows you to configure your personal settings and export a config file from
 them.
 
-### Advanced settings
-
-The [advanced settings page](/tutorial/Archipelago/advanced_settings/en) describes more options you can put in your configuration file.
-
 ### Verifying your config file
 
 If you would like to validate your config file to make sure it works, you may do so on the [YAML Validator page](/mysterycheck).

--- a/worlds/zillion/options.py
+++ b/worlds/zillion/options.py
@@ -192,6 +192,11 @@ class ZillionRedIDCardCount(Range):
     display_name = "Red ID Card count"
 
 
+class ZillionEarlyScope(Toggle):
+    """ make sure Scope is available early """
+    display_name = "early scope"
+
+
 class ZillionSkill(Range):
     """ the difficulty level of the game """
     range_start = 0
@@ -220,11 +225,6 @@ class ZillionRoomGen(Toggle):
     display_name = "room generation"
 
 
-class ZillionEarlyScope(DefaultOnToggle):
-    """ places scope in someone's sphere 1"""
-    display_name = "early scope"
-
-
 zillion_options: Dict[str, AssembleOptions] = {
     "continues": ZillionContinues,
     "floppy_req": ZillionFloppyReq,
@@ -241,10 +241,10 @@ zillion_options: Dict[str, AssembleOptions] = {
     "floppy_disk_count": ZillionFloppyDiskCount,
     "scope_count": ZillionScopeCount,
     "red_id_card_count": ZillionRedIDCardCount,
+    "early_scope": ZillionEarlyScope,
     "skill": ZillionSkill,
     "starting_cards": ZillionStartingCards,
     "room_gen": ZillionRoomGen,
-    "early_scope": ZillionEarlyScope,
 }
 
 
@@ -358,6 +358,10 @@ def validate(world: "MultiWorld", p: int) -> "Tuple[ZzOptions, Counter[str]]":
 
     room_gen = cast(ZillionRoomGen, wo.room_gen[p])
 
+    early_scope = cast(ZillionEarlyScope, wo.early_scope[p])
+    if early_scope:
+        world.early_items[p]["Scope"] = 1
+
     zz_item_counts = convert_item_counts(item_counts)
     zz_op = ZzOptions(
         zz_item_counts,
@@ -371,7 +375,7 @@ def validate(world: "MultiWorld", p: int) -> "Tuple[ZzOptions, Counter[str]]":
         floppy_req.value,
         wo.continues[p].value,
         wo.randomize_alarms[p].value,
-        False,  # early scope can be done with AP early_items
+        False,  # early scope is done with AP early_items API
         True,  # balance defense
         starting_cards.value,
         bool(room_gen.value)


### PR DESCRIPTION
Sorry, I didn't anticipate that I would be so picky.

## What is this fixing or adding?

 - move `early_items` setting into my options validation function
 - change the order of options (based on how things look on the webhost settings page)
 - change default to off, to match standalone Zillion randomizer
 - no more reason to reference advanced settings page

## How was this tested?

looked at settings page on webhost
ran unit tests
generated a seed with 2 zillion players, 1 with early scope on, 1 off